### PR TITLE
play blank mp3 before waiting for promise

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -185,6 +185,8 @@
   };
 
   var play = function(trackurl) {
+    audio.src = 'data:audio/mpeg;base64,/+MYxAAAAANIAUAAAASEEB/jwOFM/0MM/90b/+RhST//w4NFwOjf///PZu////9lns5GFDv//l9GlUIEEIAAAgIg8Ir/JGq3/+MYxDsLIj5QMYcoAP0dv9HIjUcH//yYSg+CIbkGP//8w0bLVjUP///3Z0x5QCAv/yLjwtGKTEFNRTMuOTeqqqqqqqqqqqqq/+MYxEkNmdJkUYc4AKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq';
+    audio.play();
     soundCloud.loadSoundCloud(trackurl,
       function() {
         audioSource.playStream(soundCloud.streamUrl);


### PR DESCRIPTION
This allows mobile browsers to play music after submitting the form.

The reason why this was failing before was due to the soundcloud promise taking too long.

Got the answer from http://stackoverflow.com/questions/32424775/failed-to-execute-play-on-htmlmediaelement-api-can-only-be-initiated-by-a-u

mixed with http://stackoverflow.com/questions/17452057/feature-detect-autoplay-html5-audio-audio-on-mobile-browsers